### PR TITLE
Added measure direction

### DIFF
--- a/src/aisc_plugin_interface/__init__.py
+++ b/src/aisc_plugin_interface/__init__.py
@@ -5,7 +5,12 @@ from aisc_plugin_interface.base_evaluation_plugin import (
 from aisc_plugin_interface.input_providers.base_input_provider import BaseInputProvider
 from aisc_plugin_interface.decorators.metric import metric
 from aisc_plugin_interface.decorators.evaluation_input import evaluation_input
-from aisc_plugin_interface.models.measure import Measure, MetricVisualization, ChartType
+from aisc_plugin_interface.models.measure import (
+    Measure,
+    MetricVisualization,
+    ChartType,
+    MetricDirection,
+)
 from aisc_plugin_interface.models.evaluation_input import InputDefinition, InputType
 from aisc_plugin_interface.models.task import TaskProgress
 
@@ -18,6 +23,7 @@ __all__ = [
     "Measure",
     "MetricVisualization",
     "ChartType",
+    "MetricDirection",
     "InputDefinition",
     "InputType",
     "TaskProgress",

--- a/src/aisc_plugin_interface/models/measure.py
+++ b/src/aisc_plugin_interface/models/measure.py
@@ -12,7 +12,6 @@ class MetricDirection(str, enum.Enum):
 class Measure(BaseModel):
     name: str
     description: str | None = None
-    category: str | None = None
     unit: str | None = None
     score: float
     time: datetime = datetime.now()

--- a/src/aisc_plugin_interface/models/measure.py
+++ b/src/aisc_plugin_interface/models/measure.py
@@ -4,14 +4,21 @@ import enum
 from pydantic import BaseModel
 
 
+class MetricDirection(str, enum.Enum):
+    HIGHER_IS_BETTER = "higher"
+    LOWER_IS_BETTER = "lower"
+    NEUTRAL = "neutral"
+
 class Measure(BaseModel):
     name: str
     description: str | None = None
+    category: str | None = None
     unit: str | None = None
     score: float
     time: datetime = datetime.now()
     error: str | None = None
     dimensions: dict[str, str | int | bool] | None = None
+    direction: MetricDirection | None = None
 
 
 class ChartType(str, enum.Enum):


### PR DESCRIPTION
Adds direction to the measures. Consists of 3 PR's:
- [Backend](https://github.com/lux-ai-factory/aisc-backend/pull/114)
- [Plugin interface](https://github.com/lux-ai-factory/aisc-plugin-interface/pull/25) (this one)
- [Webapp](https://github.com/lux-ai-factory/aisc-webapp/pull/71)

Example implementation:
- [Evasion plugin](https://github.com/lux-ai-factory/aisc-plugin-evasion/pull/3)

Extends the interface to include an enum-based metric direction:
```python
class MetricDirection(str, enum.Enum):
    HIGHER_IS_BETTER = "higher"
    LOWER_IS_BETTER = "lower"
    NEUTRAL = "neutral"

class Measure(BaseModel):
    ...
    direction: MetricDirection | None = None
```